### PR TITLE
fix: clear the values for the create your own poster

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -189,6 +189,9 @@ function showSavedPosters() {
 function openForm(){
   wholePage.classList.add('hidden');
   hiddenPosterForm.classList.remove('hidden');
+  imageInput.value = ''
+  titleInput.value = ''
+  quoteInput.value = ''
 }
 
 function showMainPage() {


### PR DESCRIPTION
This will make it so the input is field is empty when the "make your own poster" button is pressed (after user has already created a poster)'